### PR TITLE
bump kramdown to resolve security alert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,3 +32,6 @@ end
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.0", :install_if => Gem.win_platform?
 
+# resolve current dependabot alert not otherwise fixed with `bundle update`
+gem "kramdown", ">=2.3.0"
+


### PR DESCRIPTION
There is a security vulnerability with the kramdown gem (included in GH pages gem I assume?), and this PR manually adds the fixed version of kramdown to the gemfile.